### PR TITLE
Made method `SlurmExperiment.__str__` more informative

### DIFF
--- a/slurmqueen/experiment.py
+++ b/slurmqueen/experiment.py
@@ -206,7 +206,7 @@ class ExperimentInstance:
 
                         try:
                             val = ast.literal_eval(key_value_pair[1].strip())
-                            if isinstance(val, int) and val >= 2 ** 63:
+                            if isinstance(val, int) and val >= 2**63:
                                 val = str(
                                     val
                                 )  # int(val) would fail for a large unweighted model count

--- a/slurmqueen/experiment.py
+++ b/slurmqueen/experiment.py
@@ -201,7 +201,7 @@ class ExperimentInstance:
                             continue
 
                         key_value_pair = line.split(":", 1)
-                        if key_value_pair[1] is "inf" or key_value_pair[1] is "nan":
+                        if key_value_pair[1] == "inf" or key_value_pair[1] == "nan":
                             key_value_pair[1] = "-1"
 
                         try:

--- a/slurmqueen/experiment.py
+++ b/slurmqueen/experiment.py
@@ -338,7 +338,7 @@ class Arg:
             yield Arg.private(key, value)
         elif ">" in key or "<" in key:
             yield Arg.redirection(key, value)
-        elif key is "":
+        elif key == "":
             yield Arg.private("", value)
             for val in value:
                 yield Arg.positional(val)

--- a/slurmqueen/slurm_experiment.py
+++ b/slurmqueen/slurm_experiment.py
@@ -124,7 +124,7 @@ class SlurmExperiment(Experiment):
         pass
 
     def __str__(self):
-        return self.id.replace("\\", "/").split("/")[-1]
+        return self.id.replace("\\", "/").replace("/","_")
 
 
 class SlurmInstance(ExperimentInstance):

--- a/slurmqueen/slurm_experiment.py
+++ b/slurmqueen/slurm_experiment.py
@@ -124,7 +124,7 @@ class SlurmExperiment(Experiment):
         pass
 
     def __str__(self):
-        return self.id.replace("\\", "/").replace("/","_")
+        return self.id.replace("\\", "/").replace("/", "_")
 
 
 class SlurmInstance(ExperimentInstance):


### PR DESCRIPTION
For example, if the data dir is `a/b/c`, then the Slurm job name is `a_b_c`, no longer just `c`.